### PR TITLE
Snif fix patch according to picacomic-1.6.4

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,13 +36,13 @@ module.exports = function(grunt) {
           },
           proxies: [
             {
-              context: '/picaweb/api',
-              host: 'sakura.coz.moe',
-              port: 443,
-              https: true,
-              protocol: 'https:',
+              context: '/api',
+              host: 'picaman.picacomic.com',
+              port: 80,
+              https: false,
+              protocol: 'http:',
               headers: {
-                'host': 'sakura.coz.moe',
+                'host': 'picaman.picacomic.com',
               }
             }
           ]

--- a/src/js/logic/main.js
+++ b/src/js/logic/main.js
@@ -3,7 +3,7 @@
   var navbarCollapse = null,
     tplFnMap = {},
     mainContainer = $('#main-container'),
-    baseUrl = '/picaweb/api/',
+    baseUrl = '/api/',
     picUrlPrefix = 'http://picacomic.com/assets/comics/';
     apiUrls = {
       getCategories: baseUrl + 'categories',
@@ -285,7 +285,7 @@
         $prevPageLoader.show();
         $window.scrollTop(1);
       }
-      
+
     }
   });
 


### PR DESCRIPTION
嗅探了下picacomic的网络讯息，做了个不需要第三方个人站点的patch。能Fix #1 问题。

另外，如果没有“个人执念”倾向，请使用官方的app。picacomic需要app内置的广告和赞助维护生存。

![screenshot_2016-05-04_10-17-45](https://cloud.githubusercontent.com/assets/11864656/15003872/21f58338-11e3-11e6-985e-739272554f65.png)
